### PR TITLE
Escape password in connection string

### DIFF
--- a/DLaB.EarlyBoundGenerator/EarlyBoundGeneratorPlugin.cs
+++ b/DLaB.EarlyBoundGenerator/EarlyBoundGeneratorPlugin.cs
@@ -304,7 +304,7 @@ namespace DLaB.EarlyBoundGenerator
                 Settings.Domain = GetUserDomain();
                 Settings.Password = ConnectionDetail.GetUserPassword();
                 Settings.SupportsActions = ConnectionDetail.OrganizationMajorVersion >= Crm2013;
-                Settings.UseConnectionString = Settings.UseConnectionString || Settings.AuthType == AuthenticationProviderType.ActiveDirectory;
+                Settings.UseConnectionString = Settings.UseConnectionString;
                 Settings.UseCrmOnline = ConnectionDetail.UseOnline;
                 Settings.UserName = ConnectionDetail.UserName;
                 Settings.Url = GetUrlString();

--- a/DLaB.EarlyBoundGenerator/Logic.cs
+++ b/DLaB.EarlyBoundGenerator/Logic.cs
@@ -301,7 +301,7 @@ namespace DLaB.EarlyBoundGenerator
 
             if (!string.IsNullOrWhiteSpace(earlyBoundGeneratorConfig.Password))
             {
-                if (EarlyBoundGeneratorConfig.UseConnectionString)
+                if (earlyBoundGeneratorConfig.UseConnectionString)
                 {
                     // Fix for https://github.com/daryllabar/DLaB.Xrm.XrmToolBoxTools/issues/14 - Problem with CRM 2016 on premises with ADFS
                     // CrmSvcUtil.exe /out:entities.cs / connectionstring:"Url=https://serverName.domain.com:444/orgName;Domain=myDomain;UserName=username;Password=*****"
@@ -313,7 +313,11 @@ namespace DLaB.EarlyBoundGenerator
                     {
                         domain = "Domain=" +earlyBoundGeneratorConfig.Domain + ";";
                     }
-                    var password = earlyBoundGeneratorConfig.Password.Replace("\"", "^\"").Replace("&", "^&");  // Handle Double Quotes and &s???
+
+                    //To handle special characters, enclose in single quotes. If password contains single quotes, they must be doubled.
+                    //https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqlconnection.connectionstring.aspx
+                    var password = $"'{earlyBoundGeneratorConfig.Password.Replace("'", "''")}'";
+
                     var builder = new System.Data.Common.DbConnectionStringBuilder
                     {
                         {"A", $"Url={earlyBoundGeneratorConfig.Url};{domain}UserName={earlyBoundGeneratorConfig.UserName};Password={password}"}


### PR DESCRIPTION
These are the changes I've used to handle passwords with quotes and semicolons.
Fixes #103.

The second commit also opens up for using command line switches, instead of connection string, together with AD authentication. This works just fine with D365 on-prem. But since the connection string works for me with the password escaping, I'm not that bothered if you don't want that change.