### PR TITLE
draft: create more constructors to use base Entity constructors

### DIFF
--- a/DLaB.CrmSvcUtilExtensions/DLaB.CrmSvcUtilExtensions.csproj
+++ b/DLaB.CrmSvcUtilExtensions/DLaB.CrmSvcUtilExtensions.csproj
@@ -159,6 +159,7 @@
     <Compile Include="App_Packages\DLaB.Common.Source.1.2.0.3\VersionControl\VsTfsSourceControlProvider.cs" />
     <Compile Include="AttributeConstGeneratorBase.cs" />
     <Compile Include="BaseCustomCodeGenerationService.cs" />
+    <Compile Include="Entity\EntityConstructorsGenerator.cs" />
     <Compile Include="Entity\MultiOptionSetAttributeUpdater.cs" />
     <Compile Include="Entity\PrimaryAttributeGenerator.cs" />
     <Compile Include="Entity\AttributeConstGenerator.cs" />

--- a/DLaB.CrmSvcUtilExtensions/Entity/CustomizeCodeDomService.cs
+++ b/DLaB.CrmSvcUtilExtensions/Entity/CustomizeCodeDomService.cs
@@ -13,10 +13,11 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
         public bool CreateBaseClasses => ConfigHelper.GetAppSettingOrDefault("CreateBaseClasses", false) && !UseXrmClient;
         public static bool GenerateAnonymousTypeConstructor => ConfigHelper.GetAppSettingOrDefault("GenerateAnonymousTypeConstructor", true);
         public static bool GenerateAttributeNameConsts => ConfigHelper.GetAppSettingOrDefault("GenerateAttributeNameConsts", false);
+        public static bool GenerateConstructorsSansLogicalName => ConfigHelper.GetAppSettingOrDefault("GenerateConstructorsSansLogicalName", false);
         public static bool GenerateEnumProperties => ConfigHelper.GetAppSettingOrDefault("GenerateEnumProperties", true);
         public static bool UseXrmClient => ConfigHelper.GetAppSettingOrDefault("UseXrmClient", false);
         public IDictionary<string, string> Parameters { get; set; }
-
+        
         public CustomizeCodeDomService(IDictionary<string, string> parameters)
         {
           Parameters = parameters;
@@ -32,13 +33,13 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
             {
                 new CodeCustomization(Parameters).CustomizeCodeDom(codeUnit, services);
             }
-            if(true)
-            {
-                new EntityConstructorsGenerator().CustomizeCodeDom(codeUnit, services);
-            }
             if (AddPrimaryAttributeConsts)
             {
                 new PrimaryAttributeGenerator().CustomizeCodeDom(codeUnit, services);
+            }
+            if (GenerateConstructorsSansLogicalName)
+            {
+                new EntityConstructorsGenerator().CustomizeCodeDom(codeUnit, services);
             }
             if (GenerateAttributeNameConsts)
             {

--- a/DLaB.CrmSvcUtilExtensions/Entity/CustomizeCodeDomService.cs
+++ b/DLaB.CrmSvcUtilExtensions/Entity/CustomizeCodeDomService.cs
@@ -32,6 +32,10 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
             {
                 new CodeCustomization(Parameters).CustomizeCodeDom(codeUnit, services);
             }
+            if(true)
+            {
+                new EntityConstructorsGenerator().CustomizeCodeDom(codeUnit, services);
+            }
             if (AddPrimaryAttributeConsts)
             {
                 new PrimaryAttributeGenerator().CustomizeCodeDom(codeUnit, services);

--- a/DLaB.CrmSvcUtilExtensions/Entity/EntityConstructorsGenerator.cs
+++ b/DLaB.CrmSvcUtilExtensions/Entity/EntityConstructorsGenerator.cs
@@ -25,7 +25,7 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
         private static void AddEntityConstructors(CodeTypeDeclaration entityClass)
         {
             var entityConstructors = typeof(Microsoft.Xrm.Sdk.Entity).GetConstructors();
-            int position = 2;
+            int position = 1;
 
             foreach (var constructor in entityConstructors)
             {

--- a/DLaB.CrmSvcUtilExtensions/Entity/EntityConstructorsGenerator.cs
+++ b/DLaB.CrmSvcUtilExtensions/Entity/EntityConstructorsGenerator.cs
@@ -12,8 +12,6 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
     {
         public void CustomizeCodeDom(CodeCompileUnit codeUnit, IServiceProvider services)
         {
-            var metadataService = (IMetadataProviderService)services.GetService(typeof(IMetadataProviderService));
-            var metadata = metadataService.LoadMetadata();
             var types = codeUnit.Namespaces[0].Types;
 
             foreach (var type in types.Cast<CodeTypeDeclaration>().
@@ -27,6 +25,7 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
         private static void AddEntityConstructors(CodeTypeDeclaration entityClass)
         {
             var entityConstructors = typeof(Microsoft.Xrm.Sdk.Entity).GetConstructors();
+            int position = 2;
 
             foreach (var constructor in entityConstructors)
             {
@@ -45,8 +44,6 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
                 {
                     if(param.Name == "entityName")
                     {
-                        //codeConstructor.Parameters.Add(new CodeParameterDeclarationExpression(param.ParameterType, param.Name));
-                        //codeConstructor.BaseConstructorArgs.Add(new CodeArgumentReferenceExpression(param.Name));
                         codeConstructor.BaseConstructorArgs.Add(new CodeArgumentReferenceExpression("EntityLogicalName"));
                     }
                     else
@@ -56,7 +53,8 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
                     }
                 }
 
-                entityClass.Members.Add(codeConstructor);
+                entityClass.Members.Insert(position, codeConstructor);
+                position++;
             }
         }
 

--- a/DLaB.CrmSvcUtilExtensions/Entity/EntityConstructorsGenerator.cs
+++ b/DLaB.CrmSvcUtilExtensions/Entity/EntityConstructorsGenerator.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Crm.Services.Utility;
+using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DLaB.CrmSvcUtilExtensions.Entity
+{
+    internal class EntityConstructorsGenerator : ICustomizeCodeDomService
+    {
+        public void CustomizeCodeDom(CodeCompileUnit codeUnit, IServiceProvider services)
+        {
+            var metadataService = (IMetadataProviderService)services.GetService(typeof(IMetadataProviderService));
+            var metadata = metadataService.LoadMetadata();
+            var types = codeUnit.Namespaces[0].Types;
+
+            foreach (var type in types.Cast<CodeTypeDeclaration>().
+                                 Where(type => type.IsClass && !type.IsContextType()))
+            {
+                AddEntityConstructors(type);
+            }
+        }
+  
+
+        private static void AddEntityConstructors(CodeTypeDeclaration entityClass)
+        {
+            var entityConstructors = typeof(Microsoft.Xrm.Sdk.Entity).GetConstructors();
+
+            foreach (var constructor in entityConstructors)
+            {
+                var codeConstructor = new CodeConstructor
+                {
+                    Attributes = System.CodeDom.MemberAttributes.Public,
+                };
+
+                var paramsToConstructor = constructor.GetParameters();
+
+                // default constructor already there
+                if (paramsToConstructor.Length <= 1)
+                    continue;
+
+                foreach (var param in paramsToConstructor)
+                {
+                    if(param.Name == "entityName")
+                    {
+                        //codeConstructor.Parameters.Add(new CodeParameterDeclarationExpression(param.ParameterType, param.Name));
+                        //codeConstructor.BaseConstructorArgs.Add(new CodeArgumentReferenceExpression(param.Name));
+                        codeConstructor.BaseConstructorArgs.Add(new CodeArgumentReferenceExpression("EntityLogicalName"));
+                    }
+                    else
+                    {
+                        codeConstructor.Parameters.Add(new CodeParameterDeclarationExpression(param.ParameterType, param.Name));
+                        codeConstructor.BaseConstructorArgs.Add(new CodeArgumentReferenceExpression(param.Name));
+                    }
+                }
+
+                entityClass.Members.Add(codeConstructor);
+            }
+        }
+
+    }
+}

--- a/DLaB.EarlyBoundGenerator.Logic/Logic.cs
+++ b/DLaB.EarlyBoundGenerator.Logic/Logic.cs
@@ -235,6 +235,7 @@ namespace DLaB.EarlyBoundGenerator
                     UpdateConfigAppSetting(file, "GenerateActionAttributeNameConsts", extensions.GenerateActionAttributeNameConsts.ToString()) |
                     UpdateConfigAppSetting(file, "GenerateAttributeNameConsts", extensions.GenerateAttributeNameConsts.ToString()) |
                     UpdateConfigAppSetting(file, "GenerateAnonymousTypeConstructor", extensions.GenerateAnonymousTypeConstructor.ToString()) |
+                    UpdateConfigAppSetting(file, "GenerateConstructorsSansLogicalName", extensions.GenerateConstructorsSansLogicalName.ToString()) |
                     UpdateConfigAppSetting(file, "GenerateEntityRelationships", extensions.GenerateEntityRelationships.ToString()) |
                     UpdateConfigAppSetting(file, "GenerateEnumProperties", extensions.GenerateEnumProperties.ToString()) |
                     UpdateConfigAppSetting(file, "GenerateOnlyReferencedOptionSets", extensions.GenerateOnlyReferencedOptionSets.ToString()) |

--- a/DLaB.EarlyBoundGenerator.Logic/Settings/EarlyBoundGeneratorConfig.cs
+++ b/DLaB.EarlyBoundGenerator.Logic/Settings/EarlyBoundGeneratorConfig.cs
@@ -69,7 +69,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
         [DisplayName("Settings Version")]
         [Description("The Settings File Version.")]
         [ReadOnly(true)]
-        public string SettingsVersion{ get; set; }
+        public string SettingsVersion { get; set; }
         /// <summary>
         /// The version of the EarlyBoundGeneratorPlugin
         /// </summary>
@@ -155,7 +155,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
 
         [XmlIgnore]
         [Browsable(false)]
-        public string CrmSvcUtilPath => 
+        public string CrmSvcUtilPath =>
             Directory.Exists(CrmSvcUtilRelativePath)
                 ? CrmSvcUtilRelativePath
                 : Path.Combine(CrmSvcUtilRealtiveRootPath ?? Directory.GetCurrentDirectory(), CrmSvcUtilRelativePath);
@@ -261,6 +261,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
                 GenerateActionAttributeNameConsts = pocoConfig.GenerateActionAttributeNameConsts.GetValueOrDefault(defaultConfig.GenerateActionAttributeNameConsts),
                 GenerateAttributeNameConsts = pocoConfig.GenerateAttributeNameConsts.GetValueOrDefault(defaultConfig.GenerateAttributeNameConsts),
                 GenerateAnonymousTypeConstructor = pocoConfig.GenerateAnonymousTypeConstructor.GetValueOrDefault(defaultConfig.GenerateAnonymousTypeConstructor),
+                GenerateConstructorsSansLogicalName = pocoConfig.GenerateConstructorsSansLogicalName.GetValueOrDefault(defaultConfig.GenerateConstructorsSansLogicalName),
                 GenerateEntityRelationships = pocoConfig.GenerateEntityRelationships.GetValueOrDefault(defaultConfig.GenerateEntityRelationships),
                 GenerateEnumProperties = pocoConfig.GenerateEnumProperties.GetValueOrDefault(defaultConfig.GenerateEnumProperties),
                 GenerateOnlyReferencedOptionSets = pocoConfig.GenerateOnlyReferencedOptionSets.GetValueOrDefault(defaultConfig.GenerateOnlyReferencedOptionSets),
@@ -338,7 +339,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
 
         private void RemoveObsoleteValues(POCO.Config poco, EarlyBoundGeneratorConfig @default)
         {
-            if (CrmSvcUtilRelativePath == @"Plugins\CrmSvcUtil Ref\crmsvcutil.exe" 
+            if (CrmSvcUtilRelativePath == @"Plugins\CrmSvcUtil Ref\crmsvcutil.exe"
                 || CrmSvcUtilRelativePath == @"CrmSvcUtil Ref\crmsvcutil.exe")
             {
                 // 12.15.2016 XTB changed to use use the User directory, no plugin folder needed now
@@ -370,9 +371,9 @@ namespace DLaB.EarlyBoundGenerator.Settings
                     return @default ?? value;
                 }
 
-                var splitValues = value.Split(new[] {'|'}, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToList();
+                var splitValues = value.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToList();
                 var hash = new HashSet<string>(splitValues);
-                splitValues.AddRange(@default.Split(new[] {'|'}, StringSplitOptions.RemoveEmptyEntries).
+                splitValues.AddRange(@default.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).
                                               Where(key => !hash.Contains(key)));
 
                 return Config.ToString(splitValues);
@@ -436,8 +437,8 @@ namespace DLaB.EarlyBoundGenerator.Settings
             {
                 AudibleCompletionNotification = true,
                 IncludeCommandLine = true,
-                MaskPassword = true,    
-                ExtensionArguments = new List<Argument>(new [] {
+                MaskPassword = true,
+                ExtensionArguments = new List<Argument>(new[] {
                     // Actions
                     new Argument(CreationType.Actions, CrmSrvUtilService.CodeCustomization, "DLaB.CrmSvcUtilExtensions.Action.CustomizeCodeDomService,DLaB.CrmSvcUtilExtensions"),
                     new Argument(CreationType.Actions, CrmSrvUtilService.CodeGenerationService, "DLaB.CrmSvcUtilExtensions.Action.CustomCodeGenerationService,DLaB.CrmSvcUtilExtensions"),
@@ -455,14 +456,14 @@ namespace DLaB.EarlyBoundGenerator.Settings
                     new Argument(CreationType.OptionSets, CrmSrvUtilService.MetadataProviderService, "DLaB.CrmSvcUtilExtensions.BaseMetadataProviderService,DLaB.CrmSvcUtilExtensions")
                 }),
                 ExtensionConfig = ExtensionConfig.GetDefault(),
-                UserArguments = new List<Argument>(new [] {
-                    new Argument(CreationType.Actions, "generateActions", null), 
+                UserArguments = new List<Argument>(new[] {
+                    new Argument(CreationType.Actions, "generateActions", null),
                     new Argument(CreationType.Actions, "out",  @"EBG\Actions.cs"),
                     new Argument(CreationType.All, "namespace", "CrmEarlyBound"),
                     new Argument(CreationType.Entities, "out", @"EBG\Entities.cs"),
                     new Argument(CreationType.Entities, "servicecontextname", "CrmServiceContext"),
                     new Argument(CreationType.OptionSets, "out",  @"EBG\OptionSets.cs")
-                }), 
+                }),
             };
             @default.SettingsVersion = @default.Version;
             return @default;
@@ -480,11 +481,11 @@ namespace DLaB.EarlyBoundGenerator.Settings
                     return config;
                 }
 
-                var serializer = new XmlSerializer(typeof (POCO.Config));
+                var serializer = new XmlSerializer(typeof(POCO.Config));
                 POCO.Config poco;
                 using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
                 {
-                    poco = (POCO.Config) serializer.Deserialize(fs);
+                    poco = (POCO.Config)serializer.Deserialize(fs);
                     fs.Close();
                 }
                 var settings = new EarlyBoundGeneratorConfig(poco, filePath);
@@ -500,7 +501,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
         {
             var undoCheckoutIfUnchanged = FileRequiresUndoCheckout(filePath);
 
-            var serializer = new XmlSerializer(typeof (EarlyBoundGeneratorConfig));
+            var serializer = new XmlSerializer(typeof(EarlyBoundGeneratorConfig));
             var xmlWriterSettings = new XmlWriterSettings
             {
                 Indent = true,
@@ -584,8 +585,8 @@ namespace DLaB.EarlyBoundGenerator.Settings
 
         public Argument GetExtensionArgument(CreationType creationType, string setting)
         {
-            return ExtensionArguments.FirstOrDefault(a => a.SettingType == creationType && 
-                                                          string.Equals(a.Name, setting, StringComparison.InvariantCultureIgnoreCase)) ?? 
+            return ExtensionArguments.FirstOrDefault(a => a.SettingType == creationType &&
+                                                          string.Equals(a.Name, setting, StringComparison.InvariantCultureIgnoreCase)) ??
                 new Argument(creationType, setting, string.Empty);
         }
 
@@ -632,7 +633,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
             {
                 if (value != null)
                 {
-                    UserArguments.Add(new Argument {Name = setting, SettingType = creationType, Value = value});
+                    UserArguments.Add(new Argument { Name = setting, SettingType = creationType, Value = value });
                 }
             }
             else if (value == null)

--- a/DLaB.EarlyBoundGenerator.Logic/Settings/ExtensionConfig.cs
+++ b/DLaB.EarlyBoundGenerator.Logic/Settings/ExtensionConfig.cs
@@ -73,7 +73,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
         /// <summary>
         /// Specifies the generation of an Attributes Struct containing logical names for all attributes for the Action
         /// </summary>
-        public bool GenerateActionAttributeNameConsts { get; set; }        
+        public bool GenerateActionAttributeNameConsts { get; set; }
         /// <summary>
         /// Specifies the generation of an Attributes Struct containing logical names for all attributes for the Entity
         /// </summary>
@@ -82,6 +82,10 @@ namespace DLaB.EarlyBoundGenerator.Settings
         /// Specifies the generation of AnonymousType Constructors for entities
         /// </summary>
         public bool GenerateAnonymousTypeConstructor { get; set; }
+        /// <summary>
+        /// Adds Constructors to each early bound entity class to use constructors available to Microsoft.Xrm.Sdk.Entity
+        /// </summary>
+        public bool GenerateConstructorsSansLogicalName { get; set; }
         /// <summary>
         /// Specifies the generation of Relationships properties for Entities
         /// </summary>
@@ -197,6 +201,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
                 GenerateActionAttributeNameConsts = false,
                 GenerateAttributeNameConsts = false,
                 GenerateAnonymousTypeConstructor = true,
+                GenerateConstructorsSansLogicalName = false,
                 GenerateEntityRelationships = true,
                 GenerateEnumProperties = true,
                 GenerateOnlyReferencedOptionSets = true,
@@ -222,11 +227,11 @@ namespace DLaB.EarlyBoundGenerator.Settings
                 RemoveRuntimeVersionComment = true,
                 UnmappedProperties =
                     "DuplicateRule:BaseEntityTypeCode,MatchingEntityTypeCode|" +
-                    "InvoiceDetail:InvoiceStateCode|" + 
-                    "LeadAddress:AddressTypeCode,ShippingMethodCode|" + 
+                    "InvoiceDetail:InvoiceStateCode|" +
+                    "LeadAddress:AddressTypeCode,ShippingMethodCode|" +
                     "Organization:CurrencyFormatCode,DateFormatCode,TimeFormatCode,WeekStartDayCode|" +
-                    "Quote:StatusCode|" + 
-                    "QuoteDetail:QuoteStateCode|" + 
+                    "Quote:StatusCode|" +
+                    "QuoteDetail:QuoteStateCode|" +
                     "SalesOrderDetail:SalesOrderStateCode|",
                 UseDeprecatedOptionSetNaming = false,
                 UseTfsToCheckoutFiles = false,
@@ -248,6 +253,7 @@ namespace DLaB.EarlyBoundGenerator.Settings.POCO
         public bool? GenerateActionAttributeNameConsts { get; set; }
         public bool? GenerateAttributeNameConsts { get; set; }
         public bool? GenerateAnonymousTypeConstructor { get; set; }
+        public bool? GenerateConstructorsSansLogicalName { get; set; }
         public bool? GenerateEntityRelationships { get; set; }
         public bool? GenerateEnumProperties { get; set; }
         public bool? AddDebuggerNonUserCode { get; set; }

--- a/DLaB.EarlyBoundGenerator/Settings/SettingsMap.cs
+++ b/DLaB.EarlyBoundGenerator/Settings/SettingsMap.cs
@@ -166,6 +166,15 @@ namespace DLaB.EarlyBoundGenerator.Settings
         }
 
         [Category("Entities")]
+        [DisplayName("Generate Constructor to match Microsoft.Xrm.Sdk.Entity Constructors")]
+        [Description("Adds Constructors to each early bound entity class to use constructors available to Microsoft.Xrm.Sdk.Entity")]
+        public bool GenerateConstructorsSansLogicalName
+        {
+            get => Config.ExtensionConfig.GenerateConstructorsSansLogicalName;
+            set => Config.ExtensionConfig.GenerateConstructorsSansLogicalName = value;
+        }
+
+        [Category("Entities")]
         [DisplayName("Generate Entity Relationships")]
         [Description("Specifies if 1:N, N:1, and N:N relationships properties are generated for entities.")]
         public bool GenerateEntityRelationships

--- a/DLaB.VSSolutionAccelerator.Tests/SolutionTemplate/DLaB.EBG.Settings.xml
+++ b/DLaB.VSSolutionAccelerator.Tests/SolutionTemplate/DLaB.EBG.Settings.xml
@@ -23,6 +23,7 @@
     <GenerateActionAttributeNameConsts>false</GenerateActionAttributeNameConsts>
     <GenerateAttributeNameConsts>false</GenerateAttributeNameConsts>
     <GenerateAnonymousTypeConstructor>true</GenerateAnonymousTypeConstructor>
+    <GenerateConstructorsSansLogicalName>false</GenerateConstructorsSansLogicalName>
     <GenerateEntityRelationships>true</GenerateEntityRelationships>
     <GenerateEnumProperties>true</GenerateEnumProperties>
     <GenerateOnlyReferencedOptionSets>true</GenerateOnlyReferencedOptionSets>


### PR DESCRIPTION
DRAFT ONLY, to start the discussion of how to solve #204

Could there be an AppSetting to control this?
Now it's only if(true)

Is there a smarter way to know if the constructors are already there than based on Length <= 1?