### PR TITLE
Fixing issue where accessing OptionSet MetaData returns an error

### DIFF
--- a/DLaB.CrmSvcUtilExtensions/Entity/OptionSetMetadataAttributeGenerator.cs
+++ b/DLaB.CrmSvcUtilExtensions/Entity/OptionSetMetadataAttributeGenerator.cs
@@ -397,7 +397,7 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
                 {
                     Type = new CodeTypeReference(typeof(Attribute)),
                     Name = "attribute",
-                    InitExpression = new CodeMethodInvokeExpression(new CodeTypeReferenceExpression(typeof(CustomAttributeExtensions)), "GetCustomAttribute", new CodeVariableReferenceExpression("enumType"), new CodeTypeOfExpression(new CodeTypeReference("OptionSetMetadataAttribute")))
+                    InitExpression = new CodeMethodInvokeExpression(new CodeTypeReferenceExpression(typeof(CustomAttributeExtensions)), "GetCustomAttribute", new CodeVariableReferenceExpression("members[i]"), new CodeTypeOfExpression(new CodeTypeReference("OptionSetMetadataAttribute")))
                 },
                 new CodeConditionStatement(new CodeSnippetExpression("attribute != null"),
                     new CodeMethodReturnStatement(new CodeCastExpression(new CodeTypeReference("OptionSetMetadataAttribute"), new CodeVariableReferenceExpression("attribute"))))


### PR DESCRIPTION
When attempting to access an optionset attribute's metadata using GetMetaData extension, an error is always thrown.  Updated reference in reflection statement to inspect the enum value instead of the enum itself