### PR TITLE
Added option to generate attributes using logical names

### DIFF
--- a/DLaB.CrmSvcUtilExtensions/NamingService.cs
+++ b/DLaB.CrmSvcUtilExtensions/NamingService.cs
@@ -355,14 +355,15 @@ namespace DLaB.CrmSvcUtilExtensions
         private string GetNameForAttribute(EntityMetadata entityMetadata, AttributeMetadata attributeMetadata, IServiceProvider services, bool camelCase, bool useLogicalNames)
         {
             string attributeName;
-            if (useLogicalNames)
-            {
-                attributeName = attributeMetadata.LogicalName;
-            }
-            else if (EntityAttributeSpecifiedNames.TryGetValue(entityMetadata.LogicalName.ToLower(), out var specifiedNames) &&
+
+            if (EntityAttributeSpecifiedNames.TryGetValue(entityMetadata.LogicalName.ToLower(), out var specifiedNames) &&
                 specifiedNames.Any(s => string.Equals(s, attributeMetadata.LogicalName, StringComparison.OrdinalIgnoreCase)))
             {
                 attributeName = specifiedNames.First(s => string.Equals(s, attributeMetadata.LogicalName, StringComparison.OrdinalIgnoreCase));
+            }
+            else if (useLogicalNames)
+            {
+                attributeName = attributeMetadata.LogicalName;
             }
             else
             {

--- a/DLaB.EarlyBoundGenerator.Logic/Logic.cs
+++ b/DLaB.EarlyBoundGenerator.Logic/Logic.cs
@@ -318,6 +318,7 @@ namespace DLaB.EarlyBoundGenerator
                     UpdateConfigAppSetting(file, "SerializeMetadata", extensions.SerializeMetadata.ToString()) |
                     UpdateConfigAppSetting(file, "TokenCapitalizationOverrides", extensions.TokenCapitalizationOverrides) |
                     UpdateConfigAppSetting(file, "UseDeprecatedOptionSetNaming", extensions.UseDeprecatedOptionSetNaming.ToString()) |
+                    UpdateConfigAppSetting(file, "UseLogicalNames", extensions.UseLogicalNames.ToString()) |
                     UpdateConfigAppSetting(file, "UnmappedProperties", extensions.UnmappedProperties) |
                     UpdateConfigAppSetting(file, "UseTfsToCheckoutFiles", extensions.UseTfsToCheckoutFiles.ToString()) |
                     UpdateConfigAppSetting(file, "WaitForAttachedDebugger", extensions.WaitForAttachedDebugger.ToString())

--- a/DLaB.EarlyBoundGenerator.Logic/Settings/ExtensionConfig.cs
+++ b/DLaB.EarlyBoundGenerator.Logic/Settings/ExtensionConfig.cs
@@ -215,6 +215,10 @@ namespace DLaB.EarlyBoundGenerator.Settings
         /// </value>
         public bool UseDeprecatedOptionSetNaming { get; set; }
         /// <summary>
+        /// Generate entities and properties with logical name instead of schema name.
+        /// </summary>
+        public bool UseLogicalNames { get; set; }
+        /// <summary>
         /// Uses TFS to checkout files
         /// </summary>
         public bool UseTfsToCheckoutFiles { get; set; }
@@ -304,6 +308,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
                 SerializeMetadata = false,
                 TokenCapitalizationOverrides = "ActiveState|AccessTeam|BusinessAs|CardUci|DefaultOnCase|EmailAnd|FeatureSet|IsMsTeams|IsPaiEnabled|IsSopIntegration|MsDyUsd|O365Admin|OnHold|OwnerOnAssign|PauseStates|PartiesOnEmail|ParticipatesIn|SentOn|SlaKpi|SlaId|SyncOptIn|Timeout|UserPuid|VoiceMail|Weblink",
                 UseDeprecatedOptionSetNaming = false,
+                UseLogicalNames = false,
                 UseTfsToCheckoutFiles = false,
                 WaitForAttachedDebugger = false,
             };
@@ -362,6 +367,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
              TokenCapitalizationOverrides = GetValueOrDefault(poco.TokenCapitalizationOverrides, TokenCapitalizationOverrides);
             UnmappedProperties = GetValueOrDefault(poco.UnmappedProperties, UnmappedProperties);
             UseDeprecatedOptionSetNaming = poco.UseDeprecatedOptionSetNaming ?? UseDeprecatedOptionSetNaming;
+            UseLogicalNames = poco.UseLogicalNames ?? UseLogicalNames;
             UseTfsToCheckoutFiles = poco.UseTfsToCheckoutFiles ?? UseTfsToCheckoutFiles;
             WaitForAttachedDebugger = poco.WaitForAttachedDebugger ?? WaitForAttachedDebugger;
 
@@ -428,6 +434,7 @@ namespace DLaB.EarlyBoundGenerator.Settings.POCO
         public bool? SerializeMetadata { get; set; }
         public string TokenCapitalizationOverrides { get; set; }
         public bool? UseDeprecatedOptionSetNaming { get; set; }
+        public bool? UseLogicalNames { get; set; }
         public bool? UseTfsToCheckoutFiles { get; set; }
         public bool? WaitForAttachedDebugger { get; set; }
     }

--- a/DLaB.EarlyBoundGenerator/Settings/SettingsMap.cs
+++ b/DLaB.EarlyBoundGenerator/Settings/SettingsMap.cs
@@ -322,6 +322,15 @@ namespace DLaB.EarlyBoundGenerator.Settings
             set => Config.AudibleCompletionNotification = value;
         }
 
+        [Category("Entities")]
+        [DisplayName("Use Logical Names for Properties")]
+        [Description("Generate properties of each entity with logical name instead of schema name. May result in non working code if a field has the same logical name as the entity.")]
+        public bool UseLogicalNames
+        {
+            get => Config.ExtensionConfig.UseLogicalNames;
+            set => Config.ExtensionConfig.UseLogicalNames = value;
+        }
+
         [Category("Global")]
         [DisplayName("Camel Case Class Names")]
         [Description("Using a dictionary, attempts to correctly camelcase class/enum names.")]

--- a/DLaB.EarlyBoundGenerator/Settings/SettingsMap.cs
+++ b/DLaB.EarlyBoundGenerator/Settings/SettingsMap.cs
@@ -324,7 +324,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
 
         [Category("Entities")]
         [DisplayName("Use Logical Names for Properties")]
-        [Description("Generate properties of each entity with logical name instead of schema name. May result in non working code if a field has the same logical name as the entity.")]
+        [Description("Generate properties of entities with logical name instead of schema name. May result in breaking code if a field has the same logical name as the entity. Attribute namings can be overridden using \"Attribute Capitalization Override\" setting.")]
         public bool UseLogicalNames
         {
             get => Config.ExtensionConfig.UseLogicalNames;


### PR DESCRIPTION
In some occasions it is necessary to generate early bound entity properties using the logical names of the attributes instead of the schema name.

The change implements:
- A new option in the Entities section called **Use Logical Names for Properties**. Option is false by default.
- When the option is set to true, all entity properties will be generated using the logical names instead of schema names.