### PR TITLE
Early bound classes can be generated with "internal" visibility

### DIFF
--- a/DLaB.CrmSvcUtilExtensions/Entity/CustomizeCodeDomService.cs
+++ b/DLaB.CrmSvcUtilExtensions/Entity/CustomizeCodeDomService.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.CodeDom;
+using System.Linq;
 using Microsoft.Crm.Services.Utility;
 
 namespace DLaB.CrmSvcUtilExtensions.Entity
 {
     public class CustomizeCodeDomService : ICustomizeCodeDomService
     {
+        public static bool UseInternalAsAccessModifier => ConfigHelper.GetAppSettingOrDefault("UseInternalAsAccessModifier", false);
         public static bool AddDebuggerNonUserCode => ConfigHelper.GetAppSettingOrDefault("AddDebuggerNonUserCode", true);
         public static bool AddPrimaryAttributeConsts => ConfigHelper.GetAppSettingOrDefault("AddPrimaryAttributeConsts", true);
         public static bool CreateBaseClasses => ConfigHelper.GetAppSettingOrDefault("CreateBaseClasses", false);
@@ -74,6 +76,16 @@ namespace DLaB.CrmSvcUtilExtensions.Entity
             if (AddDebuggerNonUserCode)
             {
                 new MemberAttributes().CustomizeCodeDom(codeUnit, services);
+            }
+
+            if (UseInternalAsAccessModifier)
+            {
+                var types = codeUnit.Namespaces[0].Types;
+                foreach (var type in types.Cast<CodeTypeDeclaration>())
+                {
+                    type.TypeAttributes &= ~System.Reflection.TypeAttributes.VisibilityMask; // Resetting the visibility of the class
+                    type.TypeAttributes |= System.Reflection.TypeAttributes.NestedAssembly; // Setting to internal
+                }
             }
         }
 

--- a/DLaB.EarlyBoundGenerator.Logic/Logic.cs
+++ b/DLaB.EarlyBoundGenerator.Logic/Logic.cs
@@ -318,6 +318,7 @@ namespace DLaB.EarlyBoundGenerator
                     UpdateConfigAppSetting(file, "SerializeMetadata", extensions.SerializeMetadata.ToString()) |
                     UpdateConfigAppSetting(file, "TokenCapitalizationOverrides", extensions.TokenCapitalizationOverrides) |
                     UpdateConfigAppSetting(file, "UseDeprecatedOptionSetNaming", extensions.UseDeprecatedOptionSetNaming.ToString()) |
+                    UpdateConfigAppSetting(file, "UseInternalAsAccessModifier", extensions.UseInternalAsAccessModifier.ToString()) |
                     UpdateConfigAppSetting(file, "UseLogicalNames", extensions.UseLogicalNames.ToString()) |
                     UpdateConfigAppSetting(file, "UnmappedProperties", extensions.UnmappedProperties) |
                     UpdateConfigAppSetting(file, "UseTfsToCheckoutFiles", extensions.UseTfsToCheckoutFiles.ToString()) |

--- a/DLaB.EarlyBoundGenerator.Logic/Settings/ExtensionConfig.cs
+++ b/DLaB.EarlyBoundGenerator.Logic/Settings/ExtensionConfig.cs
@@ -223,6 +223,10 @@ namespace DLaB.EarlyBoundGenerator.Settings
         /// </summary>
         public bool UseTfsToCheckoutFiles { get; set; }
         /// <summary>
+        /// Uses "internal" as the access modifier instead of "public".
+        /// </summary>
+        public bool UseInternalAsAccessModifier { get; set; }
+        /// <summary>
         /// For Debugging Only!
         /// Waits until a debugger is attached to the CrmSvcUtil.exe before processing the command.
         /// </summary>
@@ -308,6 +312,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
                 SerializeMetadata = false,
                 TokenCapitalizationOverrides = "ActiveState|AccessTeam|BusinessAs|CardUci|DefaultOnCase|EmailAnd|FeatureSet|IsMsTeams|IsPaiEnabled|IsSopIntegration|MsDyUsd|O365Admin|OnHold|OwnerOnAssign|PauseStates|PartiesOnEmail|ParticipatesIn|SentOn|SlaKpi|SlaId|SyncOptIn|Timeout|UserPuid|VoiceMail|Weblink",
                 UseDeprecatedOptionSetNaming = false,
+                UseInternalAsAccessModifier = false,
                 UseLogicalNames = false,
                 UseTfsToCheckoutFiles = false,
                 WaitForAttachedDebugger = false,
@@ -367,6 +372,7 @@ namespace DLaB.EarlyBoundGenerator.Settings
              TokenCapitalizationOverrides = GetValueOrDefault(poco.TokenCapitalizationOverrides, TokenCapitalizationOverrides);
             UnmappedProperties = GetValueOrDefault(poco.UnmappedProperties, UnmappedProperties);
             UseDeprecatedOptionSetNaming = poco.UseDeprecatedOptionSetNaming ?? UseDeprecatedOptionSetNaming;
+            UseInternalAsAccessModifier = poco.UseInternalAsAccessModifier ?? UseInternalAsAccessModifier;
             UseLogicalNames = poco.UseLogicalNames ?? UseLogicalNames;
             UseTfsToCheckoutFiles = poco.UseTfsToCheckoutFiles ?? UseTfsToCheckoutFiles;
             WaitForAttachedDebugger = poco.WaitForAttachedDebugger ?? WaitForAttachedDebugger;
@@ -434,6 +440,7 @@ namespace DLaB.EarlyBoundGenerator.Settings.POCO
         public bool? SerializeMetadata { get; set; }
         public string TokenCapitalizationOverrides { get; set; }
         public bool? UseDeprecatedOptionSetNaming { get; set; }
+        public bool? UseInternalAsAccessModifier { get; set; }
         public bool? UseLogicalNames { get; set; }
         public bool? UseTfsToCheckoutFiles { get; set; }
         public bool? WaitForAttachedDebugger { get; set; }

--- a/DLaB.EarlyBoundGenerator/Settings/SettingsMap.cs
+++ b/DLaB.EarlyBoundGenerator/Settings/SettingsMap.cs
@@ -448,6 +448,15 @@ This helps to alleviate unnecessary differences that pop up when the classes are
             set => Config.ExtensionConfig.UseTfsToCheckoutFiles = value;
         }
 
+        [Category("Global")]
+        [DisplayName("Use 'internal' as the access modifier for the generated types")]
+        [Description("Start marking the early bound classes as 'internal' instead of 'public'")]
+        public bool UseInternalAsAccessModifier
+        {
+            get => Config.ExtensionConfig.UseInternalAsAccessModifier;
+            set => Config.ExtensionConfig.UseInternalAsAccessModifier = value;
+        }
+
         #endregion Global Properties
 
         #region Meta


### PR DESCRIPTION
In order to be able to avoid "leaking" the data layer implementation details, a developer may want to use the early bound proxies just within an assembly but convert to a separate object model before returning the data to an upper layer of the software stack.

By allowing the early bound classes to have the "internal" as access modifiers, their existence can be hidden from outside consumers of the assembly.