### PR TITLE
#249 Fix maxLength definition

### DIFF
--- a/DLaB.AttributeManager/NewTypeAttributeCreationLogic.cs
+++ b/DLaB.AttributeManager/NewTypeAttributeCreationLogic.cs
@@ -6,8 +6,8 @@ namespace DLaB.AttributeManager
     public class NewTypeAttributeCreationLogic
     {
         public static AttributeMetadata CreateText(int? maxLength = null, StringFormatName formatName = null, ImeMode? imeMode = ImeMode.Auto, string yomiOf = null, string formulaDefinition = null)
-        {
-            maxLength = formulaDefinition != null && maxLength == null ? 4000 : 100;
+        {            
+            maxLength = maxLength != null ? maxLength : (formulaDefinition != null ? 4000 : 100);
 
             return new StringAttributeMetadata
             {


### PR DESCRIPTION
maxLength argument was ignored, that's why temp attribute was always of length 100 (or 4000 if it was calculated field with formula definition). Now we set 100 or 4000 default values only if maximum length of new attribute is not set at all.