### PR TITLE
prevent multiple ProxyTypesAssemblyAttribute generated from seperate class

### DIFF
--- a/DLaB.ModelBuilderExtensions/PacModelBuilderCodeGenHack.cs
+++ b/DLaB.ModelBuilderExtensions/PacModelBuilderCodeGenHack.cs
@@ -58,7 +58,7 @@ namespace DLaB.ModelBuilderExtensions
                     FilesWritten.Add(filePath, keyValuePair.Value);
                 }
 
-                if (string.IsNullOrEmpty(str))
+                if (str == "##@")
                 {
                     ProcessModelInvoker.ModelBuilderLogger.TraceWarning("ProxyTypesAssemblyAttribute not written, Please add this to a file in your class");
                     Console.Out.WriteLine("ProxyTypesAssemblyAttribute not written, Please add [assembly: Microsoft.Xrm.Sdk.Client.ProxyTypesAssemblyAttribute()] to a file in your class");
@@ -299,7 +299,7 @@ namespace DLaB.ModelBuilderExtensions
             return method.Invoke(null, parameters);
         }
 
-        public void WriteFileWithoutCustomizations(string outputFile, string language, CodeNamespace codenamespace, IServiceProvider serviceProvider, bool writeProxyAttrib = true)
+        public void WriteFileWithoutCustomizations(string outputFile, string language, CodeNamespace codenamespace, IServiceProvider serviceProvider, bool writeProxyAttrib = false)
         {
             serviceProvider.UpdateService<ICustomizeCodeDomService>(new CustomizeCodeDomServiceEmpty());
             EnsureFileIsAccessible(outputFile);


### PR DESCRIPTION
Try to fix [#408](https://github.com/daryllabar/DLaB.Xrm.XrmToolBoxTools/issues/408)
In the **`Write`** function there already have logic that write `ProxyTypesAssemblyAttribute` into service context, if no service context is given, a warning message will pop up. 
So there is no need to add `ProxyTypesAssemblyAttribute` to anywhere, therefore the default value of `writeProxyAttrib` in `WriteFileWithoutCustomizations` should be `false`.