### PR TITLE
Captialise BookableResourceTypes choice correctly

### DIFF
--- a/DLaB.CrmSvcUtilExtensions/DLaB.Dictionary.txt
+++ b/DLaB.CrmSvcUtilExtensions/DLaB.Dictionary.txt
@@ -1044,6 +1044,7 @@ bone
 bones
 bonus
 book
+bookable
 booking
 bookings
 bookmark


### PR DESCRIPTION
Previously was captialised as `BookAbleResourceTypes.cs`