### PR TITLE
Language-Fix for Optionsets

### DIFF
--- a/DLaB.ModelBuilderExtensions/NamingService.cs
+++ b/DLaB.ModelBuilderExtensions/NamingService.cs
@@ -216,7 +216,7 @@ namespace DLaB.ModelBuilderExtensions
         private string Transliterate(OptionMetadata optionMetadata, string englishName)
         {
             var localizedLabels = optionMetadata.Label.LocalizedLabels;
-            if (LanguageCodeOverride < 0 || LanguageCodeOverride == English)
+            if (LanguageCodeOverride < 0 || LanguageCodeOverride == optionMetadata.Label.LocalizedLabels.FirstOrDefault()?.LanguageCode)
             {
                 if (IsLabelPopulated(englishName))
                 {


### PR DESCRIPTION
Hi @daryllabar,
please find the pull request,
I slightly modified our change we did in the session together. #415 
For me it was working. Maybe you can try it in one of your environments too?

I am not sure, it this works as well, if base language is always "first" in the optionset labels.

If not, we need to go with your earlier solution and remove the check in NamingService.cs Line 219

> if (LanguageCodeOverride < 0 /*|| LanguageCodeOverride == English*/)