### PR TITLE
Add #nullable enable annotation to solve CS8669 warnings

### DIFF
--- a/DLaB.ModelBuilderExtensions/PacModelBuilderCodeGenHack.cs
+++ b/DLaB.ModelBuilderExtensions/PacModelBuilderCodeGenHack.cs
@@ -247,6 +247,11 @@ namespace DLaB.ModelBuilderExtensions
                     {
                         provider.GenerateCodeFromCompileUnit(new CodeSnippetCompileUnit(string.Format(Settings.DLaBModelBuilder.FilePrefixText, Path.GetFileName(outputFile)) + Environment.NewLine), fileWriter, options);
                     }
+
+                    if (Settings.DLaBModelBuilder.MakeReferenceTypesNullable)
+                    {
+                        provider.GenerateCodeFromCompileUnit(new CodeSnippetCompileUnit("#nullable enable"), fileWriter, options);
+                    }
                     provider.GenerateCodeFromCompileUnit(new CodeSnippetCompileUnit("#pragma warning disable CS1591"), fileWriter, options);
                     if (!string.IsNullOrWhiteSpace(commandLine))
                     {


### PR DESCRIPTION
This PR adds `#nullable` annotations for generated code files. The CS8669 rule enforces #nullable annotations in auto generated files.

#500 Make reference types nullable should generate opt-in directive