### PR TITLE
Solving #320 and #543

### DIFF
--- a/DLaB.XrmToolBoxCommon/Extensions.cs
+++ b/DLaB.XrmToolBoxCommon/Extensions.cs
@@ -70,7 +70,7 @@ namespace DLaB.XrmToolBoxCommon
         //}
         //
         ///// <summary>
-        ///// Attempts to lookup the user password.  First by reflection of the userPassword, then by the old public property, then by a config value, then by crying uncle and prompting the user for the password 
+        ///// Attempts to lookup the user password.  First by reflection of the userPassword, then by the old public property, then by a config value, then by crying uncle and prompting the user for the password
         ///// </summary>
         ///// <returns></returns>
         //public static string GetUserPassword(this ConnectionDetail connection)
@@ -79,7 +79,7 @@ namespace DLaB.XrmToolBoxCommon
         //}
         //
         ///// <summary>
-        ///// Attempts to lookup the client password.  First by reflection of the clientPassword, then by a config value, then by crying uncle and prompting the user for the password 
+        ///// Attempts to lookup the client password.  First by reflection of the clientPassword, then by a config value, then by crying uncle and prompting the user for the password
         ///// </summary>
         ///// <returns></returns>
         //public static string GetClientSecret(this ConnectionDetail connection)
@@ -206,8 +206,20 @@ namespace DLaB.XrmToolBoxCommon
             return local.Label ?? defaultIfNull;
         }
 
+        public static string GetDisplayName(this EntityMetadata e, string defaultIfNull = null)
+        {
+            if (e?.DisplayName?.GetLocalOrDefaultText() is string label && !string.IsNullOrEmpty(label) && label != "N/A")
+            {
+                return label;
+            }
+            if (e?.IsIntersect == true)
+            {
+                return "M:M";
+            }
+            return defaultIfNull ?? "N/A";
+        }
 
-        #endregion // IEnumerable<EntityMetadata>
+        #endregion IEnumerable<EntityMetadata>
 
         #region OpenFileDialog
 
@@ -298,7 +310,6 @@ namespace DLaB.XrmToolBoxCommon
                 {
                     Logger.UnwireFromReportProgress(w);
                 }
-
             };
             info.AsyncArgument = asyncArgument;
 

--- a/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.Designer.cs
+++ b/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.Designer.cs
@@ -29,6 +29,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SpecifyEntitiesDialog));
             this.BtnSave = new System.Windows.Forms.Button();
             this.BtnAdd = new System.Windows.Forms.Button();
             this.BtnRemove = new System.Windows.Forms.Button();
@@ -38,7 +39,11 @@
             this.lvAvailableEntities = new System.Windows.Forms.ListView();
             this.chDisplayName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chLogicalName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.panFilter = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.txtFilter = new System.Windows.Forms.TextBox();
             this.panFilterAvailable = new System.Windows.Forms.Panel();
+            this.btnFilter = new System.Windows.Forms.Button();
             this.rbAvailPublisher = new System.Windows.Forms.RadioButton();
             this.rbAvailSolution = new System.Windows.Forms.RadioButton();
             this.rbAvailAll = new System.Windows.Forms.RadioButton();
@@ -50,8 +55,10 @@
             this.panel4 = new System.Windows.Forms.Panel();
             this.pnlFooter = new System.Windows.Forms.Panel();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.tmFilter = new System.Windows.Forms.Timer(this.components);
             this.tableLayoutPanel1.SuspendLayout();
             this.gbEntitiesAvailable.SuspendLayout();
+            this.panFilter.SuspendLayout();
             this.panFilterAvailable.SuspendLayout();
             this.gbEntitiesSelected.SuspendLayout();
             this.panel4.SuspendLayout();
@@ -122,7 +129,9 @@
             // 
             // gbEntitiesAvailable
             // 
+            this.gbEntitiesAvailable.Controls.Add(this.btnFilter);
             this.gbEntitiesAvailable.Controls.Add(this.lvAvailableEntities);
+            this.gbEntitiesAvailable.Controls.Add(this.panFilter);
             this.gbEntitiesAvailable.Controls.Add(this.panFilterAvailable);
             this.gbEntitiesAvailable.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gbEntitiesAvailable.Location = new System.Drawing.Point(3, 3);
@@ -140,9 +149,10 @@
             this.chLogicalName});
             this.lvAvailableEntities.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvAvailableEntities.FullRowSelect = true;
-            this.lvAvailableEntities.Location = new System.Drawing.Point(3, 64);
+            this.lvAvailableEntities.HideSelection = false;
+            this.lvAvailableEntities.Location = new System.Drawing.Point(3, 86);
             this.lvAvailableEntities.Name = "lvAvailableEntities";
-            this.lvAvailableEntities.Size = new System.Drawing.Size(317, 307);
+            this.lvAvailableEntities.Size = new System.Drawing.Size(317, 285);
             this.lvAvailableEntities.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.lvAvailableEntities.TabIndex = 20;
             this.lvAvailableEntities.UseCompatibleStateImageBehavior = false;
@@ -160,6 +170,36 @@
             this.chLogicalName.Text = "Logical Name";
             this.chLogicalName.Width = 150;
             // 
+            // panFilter
+            // 
+            this.panFilter.Controls.Add(this.label1);
+            this.panFilter.Controls.Add(this.txtFilter);
+            this.panFilter.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panFilter.Location = new System.Drawing.Point(3, 64);
+            this.panFilter.Name = "panFilter";
+            this.panFilter.Size = new System.Drawing.Size(317, 22);
+            this.panFilter.TabIndex = 15;
+            this.panFilter.Visible = false;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 3);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(29, 13);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Filter";
+            // 
+            // txtFilter
+            // 
+            this.txtFilter.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtFilter.Location = new System.Drawing.Point(38, 0);
+            this.txtFilter.Name = "txtFilter";
+            this.txtFilter.Size = new System.Drawing.Size(276, 20);
+            this.txtFilter.TabIndex = 0;
+            this.txtFilter.TextChanged += new System.EventHandler(this.txtFilter_TextChanged);
+            // 
             // panFilterAvailable
             // 
             this.panFilterAvailable.Controls.Add(this.rbAvailPublisher);
@@ -171,6 +211,20 @@
             this.panFilterAvailable.Name = "panFilterAvailable";
             this.panFilterAvailable.Size = new System.Drawing.Size(317, 48);
             this.panFilterAvailable.TabIndex = 10;
+            // 
+            // btnFilter
+            // 
+            this.btnFilter.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnFilter.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnFilter.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.btnFilter.Image = ((System.Drawing.Image)(resources.GetObject("btnFilter.Image")));
+            this.btnFilter.Location = new System.Drawing.Point(288, 11);
+            this.btnFilter.Name = "btnFilter";
+            this.btnFilter.Size = new System.Drawing.Size(27, 25);
+            this.btnFilter.TabIndex = 8;
+            this.toolTip1.SetToolTip(this.btnFilter, "Click to search / filter by name.\r\nClick again to hide it.");
+            this.btnFilter.UseVisualStyleBackColor = true;
+            this.btnFilter.Click += new System.EventHandler(this.btnFilter_Click);
             // 
             // rbAvailPublisher
             // 
@@ -217,7 +271,7 @@
             this.cmbFilterBy.Location = new System.Drawing.Point(1, 24);
             this.cmbFilterBy.Name = "cmbFilterBy";
             this.cmbFilterBy.Size = new System.Drawing.Size(313, 21);
-            this.cmbFilterBy.TabIndex = 3;
+            this.cmbFilterBy.TabIndex = 10;
             this.cmbFilterBy.SelectedIndexChanged += new System.EventHandler(this.ShowEntitiesByFiltering);
             // 
             // gbEntitiesSelected
@@ -238,6 +292,7 @@
             this.columnHeader2});
             this.lvSelectedEntities.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvSelectedEntities.FullRowSelect = true;
+            this.lvSelectedEntities.HideSelection = false;
             this.lvSelectedEntities.Location = new System.Drawing.Point(3, 16);
             this.lvSelectedEntities.Name = "lvSelectedEntities";
             this.lvSelectedEntities.Size = new System.Drawing.Size(318, 355);
@@ -278,6 +333,11 @@
             this.pnlFooter.Size = new System.Drawing.Size(699, 40);
             this.pnlFooter.TabIndex = 10;
             // 
+            // tmFilter
+            // 
+            this.tmFilter.Interval = 500;
+            this.tmFilter.Tick += new System.EventHandler(this.tmFilter_Tick);
+            // 
             // SpecifyEntitiesDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -294,6 +354,8 @@
             this.Load += new System.EventHandler(this.SpecifyEntitiesDialog_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.gbEntitiesAvailable.ResumeLayout(false);
+            this.panFilter.ResumeLayout(false);
+            this.panFilter.PerformLayout();
             this.panFilterAvailable.ResumeLayout(false);
             this.panFilterAvailable.PerformLayout();
             this.gbEntitiesSelected.ResumeLayout(false);
@@ -326,5 +388,10 @@
         private System.Windows.Forms.RadioButton rbAvailAll;
         private System.Windows.Forms.ComboBox cmbFilterBy;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.Panel panFilter;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox txtFilter;
+        private System.Windows.Forms.Button btnFilter;
+        private System.Windows.Forms.Timer tmFilter;
     }
 }

--- a/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.Designer.cs
+++ b/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.Designer.cs
@@ -140,7 +140,6 @@
             this.chLogicalName});
             this.lvAvailableEntities.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvAvailableEntities.FullRowSelect = true;
-            this.lvAvailableEntities.HideSelection = false;
             this.lvAvailableEntities.Location = new System.Drawing.Point(3, 64);
             this.lvAvailableEntities.Name = "lvAvailableEntities";
             this.lvAvailableEntities.Size = new System.Drawing.Size(317, 307);
@@ -148,6 +147,7 @@
             this.lvAvailableEntities.TabIndex = 20;
             this.lvAvailableEntities.UseCompatibleStateImageBehavior = false;
             this.lvAvailableEntities.View = System.Windows.Forms.View.Details;
+            this.lvAvailableEntities.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(Helper.SortListView_OnColumnClick);
             this.lvAvailableEntities.DoubleClick += new System.EventHandler(this.BtnAdd_Click);
             // 
             // chDisplayName
@@ -238,7 +238,6 @@
             this.columnHeader2});
             this.lvSelectedEntities.Dock = System.Windows.Forms.DockStyle.Fill;
             this.lvSelectedEntities.FullRowSelect = true;
-            this.lvSelectedEntities.HideSelection = false;
             this.lvSelectedEntities.Location = new System.Drawing.Point(3, 16);
             this.lvSelectedEntities.Name = "lvSelectedEntities";
             this.lvSelectedEntities.Size = new System.Drawing.Size(318, 355);
@@ -246,6 +245,7 @@
             this.lvSelectedEntities.TabIndex = 7;
             this.lvSelectedEntities.UseCompatibleStateImageBehavior = false;
             this.lvSelectedEntities.View = System.Windows.Forms.View.Details;
+            this.lvSelectedEntities.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(Helper.SortListView_OnColumnClick);
             this.lvSelectedEntities.DoubleClick += new System.EventHandler(this.BtnRemove_Click);
             // 
             // columnHeader1

--- a/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.Designer.cs
+++ b/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.Designer.cs
@@ -28,12 +28,13 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.BtnSave = new System.Windows.Forms.Button();
             this.BtnAdd = new System.Windows.Forms.Button();
             this.BtnRemove = new System.Windows.Forms.Button();
             this.BtnRefresh = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.bgEntitiesKeep = new System.Windows.Forms.GroupBox();
+            this.gbEntitiesAvailable = new System.Windows.Forms.GroupBox();
             this.lvAvailableEntities = new System.Windows.Forms.ListView();
             this.chDisplayName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chLogicalName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -42,16 +43,17 @@
             this.rbAvailSolution = new System.Windows.Forms.RadioButton();
             this.rbAvailAll = new System.Windows.Forms.RadioButton();
             this.cmbFilterBy = new System.Windows.Forms.ComboBox();
-            this.gbEntitiesExclude = new System.Windows.Forms.GroupBox();
+            this.gbEntitiesSelected = new System.Windows.Forms.GroupBox();
             this.lvSelectedEntities = new System.Windows.Forms.ListView();
             this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.panel4 = new System.Windows.Forms.Panel();
             this.pnlFooter = new System.Windows.Forms.Panel();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.tableLayoutPanel1.SuspendLayout();
-            this.bgEntitiesKeep.SuspendLayout();
+            this.gbEntitiesAvailable.SuspendLayout();
             this.panFilterAvailable.SuspendLayout();
-            this.gbEntitiesExclude.SuspendLayout();
+            this.gbEntitiesSelected.SuspendLayout();
             this.panel4.SuspendLayout();
             this.pnlFooter.SuspendLayout();
             this.SuspendLayout();
@@ -59,7 +61,7 @@
             // BtnSave
             // 
             this.BtnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.BtnSave.Location = new System.Drawing.Point(540, 15);
+            this.BtnSave.Location = new System.Drawing.Point(531, 8);
             this.BtnSave.Name = "BtnSave";
             this.BtnSave.Size = new System.Drawing.Size(75, 23);
             this.BtnSave.TabIndex = 0;
@@ -92,7 +94,7 @@
             // BtnRefresh
             // 
             this.BtnRefresh.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.BtnRefresh.Location = new System.Drawing.Point(621, 15);
+            this.BtnRefresh.Location = new System.Drawing.Point(612, 8);
             this.BtnRefresh.Name = "BtnRefresh";
             this.BtnRefresh.Size = new System.Drawing.Size(75, 23);
             this.BtnRefresh.TabIndex = 8;
@@ -106,29 +108,30 @@
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Controls.Add(this.bgEntitiesKeep, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.gbEntitiesExclude, 2, 0);
+            this.tableLayoutPanel1.Controls.Add(this.gbEntitiesAvailable, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.gbEntitiesSelected, 2, 0);
             this.tableLayoutPanel1.Controls.Add(this.panel4, 1, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 1;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 370F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(699, 370);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 380F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(699, 380);
             this.tableLayoutPanel1.TabIndex = 9;
             // 
-            // bgEntitiesKeep
+            // gbEntitiesAvailable
             // 
-            this.bgEntitiesKeep.Controls.Add(this.lvAvailableEntities);
-            this.bgEntitiesKeep.Controls.Add(this.panFilterAvailable);
-            this.bgEntitiesKeep.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.bgEntitiesKeep.Location = new System.Drawing.Point(3, 3);
-            this.bgEntitiesKeep.Name = "bgEntitiesKeep";
-            this.bgEntitiesKeep.Size = new System.Drawing.Size(323, 364);
-            this.bgEntitiesKeep.TabIndex = 0;
-            this.bgEntitiesKeep.TabStop = false;
-            this.bgEntitiesKeep.Text = "Available Entities";
+            this.gbEntitiesAvailable.Controls.Add(this.lvAvailableEntities);
+            this.gbEntitiesAvailable.Controls.Add(this.panFilterAvailable);
+            this.gbEntitiesAvailable.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.gbEntitiesAvailable.Location = new System.Drawing.Point(3, 3);
+            this.gbEntitiesAvailable.Name = "gbEntitiesAvailable";
+            this.gbEntitiesAvailable.Size = new System.Drawing.Size(323, 374);
+            this.gbEntitiesAvailable.TabIndex = 0;
+            this.gbEntitiesAvailable.TabStop = false;
+            this.gbEntitiesAvailable.Text = "Available Entities";
+            this.toolTip1.SetToolTip(this.gbEntitiesAvailable, "Total number of entities");
             // 
             // lvAvailableEntities
             // 
@@ -140,7 +143,7 @@
             this.lvAvailableEntities.HideSelection = false;
             this.lvAvailableEntities.Location = new System.Drawing.Point(3, 64);
             this.lvAvailableEntities.Name = "lvAvailableEntities";
-            this.lvAvailableEntities.Size = new System.Drawing.Size(317, 297);
+            this.lvAvailableEntities.Size = new System.Drawing.Size(317, 307);
             this.lvAvailableEntities.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.lvAvailableEntities.TabIndex = 20;
             this.lvAvailableEntities.UseCompatibleStateImageBehavior = false;
@@ -172,24 +175,24 @@
             // rbAvailPublisher
             // 
             this.rbAvailPublisher.AutoSize = true;
-            this.rbAvailPublisher.Location = new System.Drawing.Point(48, 3);
+            this.rbAvailPublisher.Location = new System.Drawing.Point(131, 3);
             this.rbAvailPublisher.Name = "rbAvailPublisher";
             this.rbAvailPublisher.Size = new System.Drawing.Size(68, 17);
-            this.rbAvailPublisher.TabIndex = 2;
+            this.rbAvailPublisher.TabIndex = 3;
             this.rbAvailPublisher.Text = "Publisher";
             this.rbAvailPublisher.UseVisualStyleBackColor = true;
-            this.rbAvailPublisher.CheckedChanged += new System.EventHandler(this.PlummingFilterAvailable);
+            this.rbAvailPublisher.CheckedChanged += new System.EventHandler(this.PopulateFilter);
             // 
             // rbAvailSolution
             // 
             this.rbAvailSolution.AutoSize = true;
-            this.rbAvailSolution.Location = new System.Drawing.Point(122, 3);
+            this.rbAvailSolution.Location = new System.Drawing.Point(58, 3);
             this.rbAvailSolution.Name = "rbAvailSolution";
             this.rbAvailSolution.Size = new System.Drawing.Size(63, 17);
-            this.rbAvailSolution.TabIndex = 3;
+            this.rbAvailSolution.TabIndex = 2;
             this.rbAvailSolution.Text = "Solution";
             this.rbAvailSolution.UseVisualStyleBackColor = true;
-            this.rbAvailSolution.CheckedChanged += new System.EventHandler(this.PlummingFilterAvailable);
+            this.rbAvailSolution.CheckedChanged += new System.EventHandler(this.PopulateFilter);
             // 
             // rbAvailAll
             // 
@@ -202,7 +205,7 @@
             this.rbAvailAll.TabStop = true;
             this.rbAvailAll.Text = "All";
             this.rbAvailAll.UseVisualStyleBackColor = true;
-            this.rbAvailAll.CheckedChanged += new System.EventHandler(this.PlummingFilterAvailable);
+            this.rbAvailAll.CheckedChanged += new System.EventHandler(this.PopulateFilter);
             // 
             // cmbFilterBy
             // 
@@ -217,16 +220,16 @@
             this.cmbFilterBy.TabIndex = 3;
             this.cmbFilterBy.SelectedIndexChanged += new System.EventHandler(this.ShowEntitiesByFiltering);
             // 
-            // gbEntitiesExclude
+            // gbEntitiesSelected
             // 
-            this.gbEntitiesExclude.Controls.Add(this.lvSelectedEntities);
-            this.gbEntitiesExclude.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gbEntitiesExclude.Location = new System.Drawing.Point(372, 3);
-            this.gbEntitiesExclude.Name = "gbEntitiesExclude";
-            this.gbEntitiesExclude.Size = new System.Drawing.Size(324, 364);
-            this.gbEntitiesExclude.TabIndex = 1;
-            this.gbEntitiesExclude.TabStop = false;
-            this.gbEntitiesExclude.Text = "Selected Entities";
+            this.gbEntitiesSelected.Controls.Add(this.lvSelectedEntities);
+            this.gbEntitiesSelected.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.gbEntitiesSelected.Location = new System.Drawing.Point(372, 3);
+            this.gbEntitiesSelected.Name = "gbEntitiesSelected";
+            this.gbEntitiesSelected.Size = new System.Drawing.Size(324, 374);
+            this.gbEntitiesSelected.TabIndex = 1;
+            this.gbEntitiesSelected.TabStop = false;
+            this.gbEntitiesSelected.Text = "Selected Entities";
             // 
             // lvSelectedEntities
             // 
@@ -238,7 +241,7 @@
             this.lvSelectedEntities.HideSelection = false;
             this.lvSelectedEntities.Location = new System.Drawing.Point(3, 16);
             this.lvSelectedEntities.Name = "lvSelectedEntities";
-            this.lvSelectedEntities.Size = new System.Drawing.Size(318, 345);
+            this.lvSelectedEntities.Size = new System.Drawing.Size(318, 355);
             this.lvSelectedEntities.Sorting = System.Windows.Forms.SortOrder.Ascending;
             this.lvSelectedEntities.TabIndex = 7;
             this.lvSelectedEntities.UseCompatibleStateImageBehavior = false;
@@ -262,7 +265,7 @@
             this.panel4.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel4.Location = new System.Drawing.Point(332, 3);
             this.panel4.Name = "panel4";
-            this.panel4.Size = new System.Drawing.Size(34, 364);
+            this.panel4.Size = new System.Drawing.Size(34, 374);
             this.panel4.TabIndex = 2;
             // 
             // pnlFooter
@@ -270,9 +273,9 @@
             this.pnlFooter.Controls.Add(this.BtnRefresh);
             this.pnlFooter.Controls.Add(this.BtnSave);
             this.pnlFooter.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.pnlFooter.Location = new System.Drawing.Point(0, 370);
+            this.pnlFooter.Location = new System.Drawing.Point(0, 380);
             this.pnlFooter.Name = "pnlFooter";
-            this.pnlFooter.Size = new System.Drawing.Size(699, 50);
+            this.pnlFooter.Size = new System.Drawing.Size(699, 40);
             this.pnlFooter.TabIndex = 10;
             // 
             // SpecifyEntitiesDialog
@@ -290,10 +293,10 @@
             this.Text = "Select Entities";
             this.Load += new System.EventHandler(this.SpecifyEntitiesDialog_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
-            this.bgEntitiesKeep.ResumeLayout(false);
+            this.gbEntitiesAvailable.ResumeLayout(false);
             this.panFilterAvailable.ResumeLayout(false);
             this.panFilterAvailable.PerformLayout();
-            this.gbEntitiesExclude.ResumeLayout(false);
+            this.gbEntitiesSelected.ResumeLayout(false);
             this.panel4.ResumeLayout(false);
             this.pnlFooter.ResumeLayout(false);
             this.ResumeLayout(false);
@@ -307,8 +310,8 @@
         private System.Windows.Forms.Button BtnRemove;
         private System.Windows.Forms.Button BtnRefresh;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
-        private System.Windows.Forms.GroupBox bgEntitiesKeep;
-        private System.Windows.Forms.GroupBox gbEntitiesExclude;
+        private System.Windows.Forms.GroupBox gbEntitiesAvailable;
+        private System.Windows.Forms.GroupBox gbEntitiesSelected;
         private System.Windows.Forms.Panel panel4;
         private System.Windows.Forms.Panel pnlFooter;
         private System.Windows.Forms.ListView lvAvailableEntities;
@@ -322,5 +325,6 @@
         private System.Windows.Forms.RadioButton rbAvailSolution;
         private System.Windows.Forms.RadioButton rbAvailAll;
         private System.Windows.Forms.ComboBox cmbFilterBy;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.Designer.cs
+++ b/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.Designer.cs
@@ -34,17 +34,23 @@
             this.BtnRefresh = new System.Windows.Forms.Button();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.bgEntitiesKeep = new System.Windows.Forms.GroupBox();
-            this.lvKeptEntities = new System.Windows.Forms.ListView();
+            this.lvAvailableEntities = new System.Windows.Forms.ListView();
             this.chDisplayName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.chLogicalName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.panFilterAvailable = new System.Windows.Forms.Panel();
+            this.rbAvailPublisher = new System.Windows.Forms.RadioButton();
+            this.rbAvailSolution = new System.Windows.Forms.RadioButton();
+            this.rbAvailAll = new System.Windows.Forms.RadioButton();
+            this.cmbFilterBy = new System.Windows.Forms.ComboBox();
             this.gbEntitiesExclude = new System.Windows.Forms.GroupBox();
-            this.lvExcludedEntities = new System.Windows.Forms.ListView();
+            this.lvSelectedEntities = new System.Windows.Forms.ListView();
             this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.panel4 = new System.Windows.Forms.Panel();
             this.pnlFooter = new System.Windows.Forms.Panel();
             this.tableLayoutPanel1.SuspendLayout();
             this.bgEntitiesKeep.SuspendLayout();
+            this.panFilterAvailable.SuspendLayout();
             this.gbEntitiesExclude.SuspendLayout();
             this.panel4.SuspendLayout();
             this.pnlFooter.SuspendLayout();
@@ -114,31 +120,32 @@
             // 
             // bgEntitiesKeep
             // 
-            this.bgEntitiesKeep.Controls.Add(this.lvKeptEntities);
+            this.bgEntitiesKeep.Controls.Add(this.lvAvailableEntities);
+            this.bgEntitiesKeep.Controls.Add(this.panFilterAvailable);
             this.bgEntitiesKeep.Dock = System.Windows.Forms.DockStyle.Fill;
             this.bgEntitiesKeep.Location = new System.Drawing.Point(3, 3);
             this.bgEntitiesKeep.Name = "bgEntitiesKeep";
             this.bgEntitiesKeep.Size = new System.Drawing.Size(323, 364);
             this.bgEntitiesKeep.TabIndex = 0;
             this.bgEntitiesKeep.TabStop = false;
-            this.bgEntitiesKeep.Text = "All Entities";
+            this.bgEntitiesKeep.Text = "Available Entities";
             // 
-            // lvKeptEntities
+            // lvAvailableEntities
             // 
-            this.lvKeptEntities.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvAvailableEntities.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.chDisplayName,
             this.chLogicalName});
-            this.lvKeptEntities.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lvKeptEntities.FullRowSelect = true;
-            this.lvKeptEntities.Location = new System.Drawing.Point(3, 16);
-            this.lvKeptEntities.Name = "lvKeptEntities";
-            this.lvKeptEntities.Size = new System.Drawing.Size(317, 345);
-            this.lvKeptEntities.Sorting = System.Windows.Forms.SortOrder.Ascending;
-            this.lvKeptEntities.TabIndex = 2;
-            this.lvKeptEntities.UseCompatibleStateImageBehavior = false;
-            this.lvKeptEntities.View = System.Windows.Forms.View.Details;
-            this.lvKeptEntities.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(Helper.SortListView_OnColumnClick);
-            this.lvKeptEntities.DoubleClick += new System.EventHandler(this.BtnAdd_Click);
+            this.lvAvailableEntities.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lvAvailableEntities.FullRowSelect = true;
+            this.lvAvailableEntities.HideSelection = false;
+            this.lvAvailableEntities.Location = new System.Drawing.Point(3, 64);
+            this.lvAvailableEntities.Name = "lvAvailableEntities";
+            this.lvAvailableEntities.Size = new System.Drawing.Size(317, 297);
+            this.lvAvailableEntities.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this.lvAvailableEntities.TabIndex = 20;
+            this.lvAvailableEntities.UseCompatibleStateImageBehavior = false;
+            this.lvAvailableEntities.View = System.Windows.Forms.View.Details;
+            this.lvAvailableEntities.DoubleClick += new System.EventHandler(this.BtnAdd_Click);
             // 
             // chDisplayName
             // 
@@ -150,9 +157,69 @@
             this.chLogicalName.Text = "Logical Name";
             this.chLogicalName.Width = 150;
             // 
+            // panFilterAvailable
+            // 
+            this.panFilterAvailable.Controls.Add(this.rbAvailPublisher);
+            this.panFilterAvailable.Controls.Add(this.rbAvailSolution);
+            this.panFilterAvailable.Controls.Add(this.rbAvailAll);
+            this.panFilterAvailable.Controls.Add(this.cmbFilterBy);
+            this.panFilterAvailable.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panFilterAvailable.Location = new System.Drawing.Point(3, 16);
+            this.panFilterAvailable.Name = "panFilterAvailable";
+            this.panFilterAvailable.Size = new System.Drawing.Size(317, 48);
+            this.panFilterAvailable.TabIndex = 10;
+            // 
+            // rbAvailPublisher
+            // 
+            this.rbAvailPublisher.AutoSize = true;
+            this.rbAvailPublisher.Location = new System.Drawing.Point(48, 3);
+            this.rbAvailPublisher.Name = "rbAvailPublisher";
+            this.rbAvailPublisher.Size = new System.Drawing.Size(68, 17);
+            this.rbAvailPublisher.TabIndex = 2;
+            this.rbAvailPublisher.Text = "Publisher";
+            this.rbAvailPublisher.UseVisualStyleBackColor = true;
+            this.rbAvailPublisher.CheckedChanged += new System.EventHandler(this.PlummingFilterAvailable);
+            // 
+            // rbAvailSolution
+            // 
+            this.rbAvailSolution.AutoSize = true;
+            this.rbAvailSolution.Location = new System.Drawing.Point(122, 3);
+            this.rbAvailSolution.Name = "rbAvailSolution";
+            this.rbAvailSolution.Size = new System.Drawing.Size(63, 17);
+            this.rbAvailSolution.TabIndex = 3;
+            this.rbAvailSolution.Text = "Solution";
+            this.rbAvailSolution.UseVisualStyleBackColor = true;
+            this.rbAvailSolution.CheckedChanged += new System.EventHandler(this.PlummingFilterAvailable);
+            // 
+            // rbAvailAll
+            // 
+            this.rbAvailAll.AutoSize = true;
+            this.rbAvailAll.Checked = true;
+            this.rbAvailAll.Location = new System.Drawing.Point(6, 3);
+            this.rbAvailAll.Name = "rbAvailAll";
+            this.rbAvailAll.Size = new System.Drawing.Size(36, 17);
+            this.rbAvailAll.TabIndex = 1;
+            this.rbAvailAll.TabStop = true;
+            this.rbAvailAll.Text = "All";
+            this.rbAvailAll.UseVisualStyleBackColor = true;
+            this.rbAvailAll.CheckedChanged += new System.EventHandler(this.PlummingFilterAvailable);
+            // 
+            // cmbFilterBy
+            // 
+            this.cmbFilterBy.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.cmbFilterBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbFilterBy.Enabled = false;
+            this.cmbFilterBy.FormattingEnabled = true;
+            this.cmbFilterBy.Location = new System.Drawing.Point(1, 24);
+            this.cmbFilterBy.Name = "cmbFilterBy";
+            this.cmbFilterBy.Size = new System.Drawing.Size(313, 21);
+            this.cmbFilterBy.TabIndex = 3;
+            this.cmbFilterBy.SelectedIndexChanged += new System.EventHandler(this.ShowEntitiesByFiltering);
+            // 
             // gbEntitiesExclude
             // 
-            this.gbEntitiesExclude.Controls.Add(this.lvExcludedEntities);
+            this.gbEntitiesExclude.Controls.Add(this.lvSelectedEntities);
             this.gbEntitiesExclude.Dock = System.Windows.Forms.DockStyle.Fill;
             this.gbEntitiesExclude.Location = new System.Drawing.Point(372, 3);
             this.gbEntitiesExclude.Name = "gbEntitiesExclude";
@@ -161,22 +228,22 @@
             this.gbEntitiesExclude.TabStop = false;
             this.gbEntitiesExclude.Text = "Selected Entities";
             // 
-            // lvExcludedEntities
+            // lvSelectedEntities
             // 
-            this.lvExcludedEntities.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.lvSelectedEntities.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.columnHeader1,
             this.columnHeader2});
-            this.lvExcludedEntities.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lvExcludedEntities.FullRowSelect = true;
-            this.lvExcludedEntities.Location = new System.Drawing.Point(3, 16);
-            this.lvExcludedEntities.Name = "lvExcludedEntities";
-            this.lvExcludedEntities.Size = new System.Drawing.Size(318, 345);
-            this.lvExcludedEntities.Sorting = System.Windows.Forms.SortOrder.Ascending;
-            this.lvExcludedEntities.TabIndex = 7;
-            this.lvExcludedEntities.UseCompatibleStateImageBehavior = false;
-            this.lvExcludedEntities.View = System.Windows.Forms.View.Details;
-            this.lvExcludedEntities.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(Helper.SortListView_OnColumnClick);
-            this.lvExcludedEntities.DoubleClick += new System.EventHandler(this.BtnRemove_Click);
+            this.lvSelectedEntities.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lvSelectedEntities.FullRowSelect = true;
+            this.lvSelectedEntities.HideSelection = false;
+            this.lvSelectedEntities.Location = new System.Drawing.Point(3, 16);
+            this.lvSelectedEntities.Name = "lvSelectedEntities";
+            this.lvSelectedEntities.Size = new System.Drawing.Size(318, 345);
+            this.lvSelectedEntities.Sorting = System.Windows.Forms.SortOrder.Ascending;
+            this.lvSelectedEntities.TabIndex = 7;
+            this.lvSelectedEntities.UseCompatibleStateImageBehavior = false;
+            this.lvSelectedEntities.View = System.Windows.Forms.View.Details;
+            this.lvSelectedEntities.DoubleClick += new System.EventHandler(this.BtnRemove_Click);
             // 
             // columnHeader1
             // 
@@ -216,13 +283,16 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.pnlFooter);
             this.Margin = new System.Windows.Forms.Padding(8, 7, 8, 7);
+            this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(541, 425);
             this.Name = "SpecifyEntitiesDialog";
-            this.Text = "Select Entities";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Select Entities";
             this.Load += new System.EventHandler(this.SpecifyEntitiesDialog_Load);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.bgEntitiesKeep.ResumeLayout(false);
+            this.panFilterAvailable.ResumeLayout(false);
+            this.panFilterAvailable.PerformLayout();
             this.gbEntitiesExclude.ResumeLayout(false);
             this.panel4.ResumeLayout(false);
             this.pnlFooter.ResumeLayout(false);
@@ -241,11 +311,16 @@
         private System.Windows.Forms.GroupBox gbEntitiesExclude;
         private System.Windows.Forms.Panel panel4;
         private System.Windows.Forms.Panel pnlFooter;
-        private System.Windows.Forms.ListView lvKeptEntities;
+        private System.Windows.Forms.ListView lvAvailableEntities;
         private System.Windows.Forms.ColumnHeader chDisplayName;
         private System.Windows.Forms.ColumnHeader chLogicalName;
-        private System.Windows.Forms.ListView lvExcludedEntities;
+        private System.Windows.Forms.ListView lvSelectedEntities;
         private System.Windows.Forms.ColumnHeader columnHeader1;
         private System.Windows.Forms.ColumnHeader columnHeader2;
+        private System.Windows.Forms.Panel panFilterAvailable;
+        private System.Windows.Forms.RadioButton rbAvailPublisher;
+        private System.Windows.Forms.RadioButton rbAvailSolution;
+        private System.Windows.Forms.RadioButton rbAvailAll;
+        private System.Windows.Forms.ComboBox cmbFilterBy;
     }
 }

--- a/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.cs
+++ b/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Metadata;
+using Microsoft.Xrm.Sdk.Query;
+using Source.DLaB.Xrm;
 using XrmToolBox.Extensibility;
 
 // ReSharper disable once CheckNamespace
@@ -10,14 +13,13 @@ namespace DLaB.XrmToolBoxCommon.Forms
 {
     public partial class SpecifyEntitiesDialog : DialogBase
     {
+        private List<EntityMetadata> allEntities;
+        private List<Entity> solutions;
+        private List<Entity> publishers;
+
         public HashSet<string> SpecifiedEntities { get; set; }
 
         #region Constructor / Load
-
-        public SpecifyEntitiesDialog()
-        {
-            InitializeComponent();
-        }
 
         public SpecifyEntitiesDialog(PluginControlBase callingControl)
             : base(callingControl)
@@ -37,28 +39,29 @@ namespace DLaB.XrmToolBoxCommon.Forms
         {
             try
             {
-                lvKeptEntities.BeginUpdate();
-                lvExcludedEntities.BeginUpdate();
+                lvAvailableEntities.BeginUpdate();
+                lvSelectedEntities.BeginUpdate();
                 Enable(false);
-                lvKeptEntities.Items.Clear();
-                lvExcludedEntities.Items.Clear();
-                var localEntities = entities.ToList(); // Keep from multiple Enumerations
+                lvAvailableEntities.Items.Clear();
+                lvSelectedEntities.Items.Clear();
+                allEntities = entities.ToList(); // Keep from multiple Enumerations
 
-                lvExcludedEntities.Items.AddRange(localEntities.Where(e => SpecifiedEntities.Contains(e.LogicalName)).Select(e => new ListViewItem(e.DisplayName.UserLocalizedLabel?.Label ?? "N/A") { SubItems = { e.LogicalName } }).ToArray());
-                lvKeptEntities.Items.AddRange(localEntities.Where(e => !SpecifiedEntities.Contains(e.LogicalName)).Select(e => new ListViewItem(e.DisplayName.UserLocalizedLabel?.Label ?? "N/A") { SubItems = { e.LogicalName } }).ToArray());
+                lvSelectedEntities.Items.AddRange(allEntities.Where(e => SpecifiedEntities.Contains(e.LogicalName)).Select(e => new ListViewItem(e.DisplayName.UserLocalizedLabel?.Label ?? "N/A") { SubItems = { e.LogicalName }, Tag = e }).ToArray());
+                ShowEntitiesByFiltering();
             }
             finally
             {
-                lvKeptEntities.EndUpdate();
-                lvExcludedEntities.EndUpdate();
+                lvAvailableEntities.EndUpdate();
+                lvSelectedEntities.EndUpdate();
                 Enable(true);
             }
         }
 
         private void Enable(bool enable)
         {
-            lvKeptEntities.Enabled = enable;
-            lvExcludedEntities.Enabled = enable;
+            panFilterAvailable.Enabled = enable;
+            lvAvailableEntities.Enabled = enable;
+            lvSelectedEntities.Enabled = enable;
             BtnAdd.Enabled = enable;
             BtnRemove.Enabled = enable;
             BtnSave.Enabled = enable;
@@ -67,7 +70,7 @@ namespace DLaB.XrmToolBoxCommon.Forms
 
         private void BtnSave_Click(object sender, EventArgs e)
         {
-            SpecifiedEntities = new HashSet<string>(lvExcludedEntities.Items.Cast<ListViewItem>().Select(i => i.SubItems[1].Text));
+            SpecifiedEntities = new HashSet<string>(lvSelectedEntities.Items.Cast<ListViewItem>().Select(i => i.SubItems[1].Text));
             DialogResult = DialogResult.OK;
             Close();
         }
@@ -85,22 +88,178 @@ namespace DLaB.XrmToolBoxCommon.Forms
 
         private void BtnAdd_Click(object sender, EventArgs e)
         {
-            var values = lvKeptEntities.SelectedItems.Cast<ListViewItem>().ToArray();
+            var values = lvAvailableEntities.SelectedItems.Cast<ListViewItem>().ToArray();
             foreach (var value in values)
             {
-                lvKeptEntities.Items.Remove(value);
+                lvAvailableEntities.Items.Remove(value);
             }
-            lvExcludedEntities.Items.AddRange(values);
+            lvSelectedEntities.Items.AddRange(values);
         }
 
         private void BtnRemove_Click(object sender, EventArgs e)
         {
-            var values = lvExcludedEntities.SelectedItems.Cast<ListViewItem>().ToArray();
+            var values = lvSelectedEntities.SelectedItems.Cast<ListViewItem>().ToArray();
             foreach (var value in values)
             {
-                lvExcludedEntities.Items.Remove(value);
+                lvSelectedEntities.Items.Remove(value);
             }
-            lvKeptEntities.Items.AddRange(values);
+            lvAvailableEntities.Items.AddRange(values);
         }
+
+        private void PlummingFilterAvailable(object sender = null, EventArgs ea = null)
+        {
+            lvAvailableEntities.Items.Clear();
+            if (allEntities == null)
+            {
+                return; // No entities loaded yet
+            }
+            if (rbAvailSolution.Checked)
+            {
+                if (solutions == null)
+                {
+                    LoadSolutions();
+                }
+                cmbFilterBy.Items.Clear();
+                cmbFilterBy.Items.Add("");
+                cmbFilterBy.Items.AddRange(solutions
+                    .Select(s => new EntityProxy(s, $"{s.GetAttributeValue<string>("friendlyname")} ({s.GetAliasedValue<string>("P.friendlyname")})"))
+                    .ToArray());
+                cmbFilterBy.Enabled = true;
+            }
+            else if (rbAvailPublisher.Checked)
+            {
+                if (publishers == null)
+                {
+                    LoadPublishers();
+                }
+                cmbFilterBy.Items.Clear();
+                cmbFilterBy.Items.Add("");
+                cmbFilterBy.Items.AddRange(publishers
+                    .Select(p => new EntityProxy(p, $"{p.GetAttributeValue<string>("friendlyname")} ({p.GetAliasedValue<string>("customizationprefix")})"))
+                    .ToArray());
+                cmbFilterBy.Enabled = true;
+            }
+            else
+            {
+                // Show all entities
+                lvAvailableEntities.Items.AddRange(allEntities
+                    .Select(e => new ListViewItem(e.DisplayName.UserLocalizedLabel?.Label ?? "N/A") { Tag = e, SubItems = { e.LogicalName } })
+                    .ToArray());
+                cmbFilterBy.Enabled = false;
+            }
+            ShowEntitiesByFiltering();
+        }
+
+        private void ShowEntitiesByFiltering(object sender = null, EventArgs ea = null)
+        {
+            lvAvailableEntities.Items.Clear();
+            var selectedentityguids = new List<Guid>();
+            if (rbAvailAll.Checked)
+            {
+                selectedentityguids = allEntities.Select(e => e.MetadataId ?? Guid.Empty).ToList();
+            }
+            else if (cmbFilterBy.SelectedItem is EntityProxy proxy && proxy.Entity is Entity selected)
+            {
+                var query = new QueryExpression("solutioncomponent");
+                query.ColumnSet.AddColumns("objectid", "solutioncomponentid", "rootcomponentbehavior", "rootsolutioncomponentid", "ismetadata", "componenttype");
+                if (selected.LogicalName == "solution")
+                {
+                    query.Criteria.AddCondition("solutionid", ConditionOperator.Equal, selected.Id);
+                }
+                else if (selected.LogicalName == "publisher")
+                {
+                    var query_solution = query.AddLink("solution", "solutionid", "solutionid");
+                    query_solution.LinkCriteria.AddCondition("publisherid", ConditionOperator.Equal, selected.Id);
+                }
+                else
+                {
+                    query.Criteria.AddCondition("solutionid", ConditionOperator.Null);
+                }
+                query.Criteria.AddCondition("componenttype", ConditionOperator.Equal, 1);
+                try
+                {
+                    var result = CallingControl.Service.RetrieveMultiple(query);
+                    selectedentityguids = result.Entities.Select(e => e.GetAttributeValue<Guid>("objectid")).ToList();
+                }
+                catch (Exception ex)
+                {
+                    CallingControl.ShowErrorDialog(ex, "Loading Solutions Entities");
+                }
+            }
+
+            var selectedentities = lvSelectedEntities.Items.Cast<ListViewItem>().Select(i => i.Tag as EntityMetadata).ToList();
+
+            lvAvailableEntities.Items.AddRange(allEntities
+                .Where(e => selectedentityguids.Contains(e.MetadataId ?? Guid.Empty))
+                .Where(e => !selectedentities.Contains(e))
+                .Select(e => new ListViewItem(e.DisplayName.UserLocalizedLabel?.Label ?? "N/A") { Tag = e, SubItems = { e.LogicalName } })
+                .ToArray());
+        }
+
+        private void LoadSolutions()
+        {
+            if (CallingControl.Service == null)
+            {
+                solutions = new List<Entity>();
+                return;
+            }
+            var query = new QueryExpression("solution");
+            query.ColumnSet.AddColumns("friendlyname", "uniquename", "ismanaged", "isvisible", "version");
+            query.Criteria.AddCondition("isvisible", ConditionOperator.Equal, true);
+            query.AddOrder("ismanaged", OrderType.Descending);
+            query.AddOrder("friendlyname", OrderType.Ascending);
+            var publisher = query.AddLink("publisher", "publisherid", "publisherid");
+            publisher.EntityAlias = "P";
+            publisher.Columns.AddColumns("customizationprefix", "uniquename", "friendlyname");
+            try
+            {
+                solutions = CallingControl.Service.RetrieveMultiple(query).Entities.ToList();
+            }
+            catch (Exception ex)
+            {
+                CallingControl.ShowErrorDialog(ex, "Loading Solutions");
+            }
+        }
+
+        private void LoadPublishers()
+        {
+            if (CallingControl.Service == null)
+            {
+                publishers = new List<Entity>();
+                return;
+            }
+            var query = new QueryExpression("publisher");
+            query.ColumnSet.AddColumns("publisherid", "friendlyname", "customizationprefix");
+            var query_solution = new LinkEntity("publisher", "solution", "publisherid", "publisherid", JoinOperator.Any);
+            query.Criteria.AnyAllFilterLinkEntity = query_solution;
+            query_solution.LinkCriteria.AddCondition("isvisible", ConditionOperator.Equal, true);
+            query.AddOrder("friendlyname", OrderType.Ascending);
+            try
+            {
+                publishers = CallingControl.Service.RetrieveMultiple(query).Entities.ToList();
+            }
+            catch (Exception ex)
+            {
+                CallingControl.ShowErrorDialog(ex, "Loading Publishers");
+            }
+            finally
+            {
+                Cursor = Cursors.Default;
+            }
+        }
+    }
+
+    public class EntityProxy
+    {
+        private string displayName;
+        public Entity Entity;
+
+        public EntityProxy(Entity entity, string displayname)
+        {
+            Entity = entity ?? throw new ArgumentNullException(nameof(entity));
+            displayName = displayname;
+        }
+
+        public override string ToString() => displayName ?? Entity?.Id.ToString() ?? "N/A";
     }
 }

--- a/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.resx
+++ b/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.resx
+++ b/DLaB.XrmToolBoxCommon/Forms/SpecifyEntitiesDialog.resx
@@ -117,7 +117,21 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="btnFilter.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        DgAACw4BQL7hQQAAAO1JREFUOE/N000rRUEYB/AfohSiGxaWSj6ApbfFtVF2unwDG8lKWSglCxsL2UoW
+        7krZkKK81S2fwyfRaE5Nz0Vn6VenM+f5P1Nz5szhvxrBApYxHsO/DOIMbzjGIR7QRiM2R/25eTMGWEIH
+        ozEo7WInj7dxg7kiX8V58dzlHQNoYS+GWepJK+3Sg+c8nkFfyCsXmI7Fymu+r6M3ZJVrTMVi5R4TsVhI
+        r5c28lcruIzFwgG2YjHaxxUmi9owTvCJWywW2Y+auMuHKV1P2MARTvNmz8dJdaRD9II1fGA2NtQxlr/W
+        I4ZiWFeamP6Zb19EoR++GxAdCAAAAABJRU5ErkJggg==
+</value>
+  </data>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="tmFilter.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>115, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
The `SpecifyEntitiesDialog` form can now filter on all gazillion entities by:
* Solution (only showing the entities in that selected solution)
* Publisher (only showing the entities in solutions by the selected publisher)
* Free text searching in both entities' Display Name and `LogicalName`

I just dislike seeing the very long list of entities.