### PR TITLE
Skip writing serializedMetadataRelativeFilePath when metadata serialization is unused

### DIFF
--- a/DLaB.EarlyBoundGeneratorV2.Logic/Settings/ExtensionConfig.cs
+++ b/DLaB.EarlyBoundGeneratorV2.Logic/Settings/ExtensionConfig.cs
@@ -535,7 +535,7 @@ namespace DLaB.EarlyBoundGeneratorV2.Settings
             writer.AddProperty(nameof(ReadSerializedMetadata), ReadSerializedMetadata);
             writer.AddProperty(nameof(RemoveRuntimeVersionComment), RemoveRuntimeVersionComment);
             AddOptionalBoolProperty("ReplaceEnumPropertiesWithOptionSet", !GenerateEnumProperties, generateOptionSetProperties);
-            if (!string.IsNullOrWhiteSpace(SerializedMetadataRelativeFilePath))
+            if (!string.IsNullOrWhiteSpace(SerializedMetadataRelativeFilePath) && (ReadSerializedMetadata || SerializeMetadata))
             {
                 writer.AddProperty("SerializedMetadataRelativeFilePath", SerializedMetadataRelativeFilePath);
             }

--- a/DLaB.EarlyBoundGeneratorV2/EarlyBoundGeneratorPlugin.cs
+++ b/DLaB.EarlyBoundGeneratorV2/EarlyBoundGeneratorPlugin.cs
@@ -365,7 +365,14 @@ Please consider clicking the save button in the top right to save the settings w
             defaultConfig.ExtensionConfig.XrmToolBoxPluginPath = Paths.PluginsPath;
             // Settings.SetExtensionArgument(CreationType.OptionSets, CrmSrvUtilService.CodeWriterFilter, defaultConfig.GetExtensionArgument(CreationType.OptionSets, CrmSrvUtilService.CodeWriterFilter).Value);
             // Settings.SetExtensionArgument(CreationType.OptionSets, CrmSrvUtilService.NamingService, defaultConfig.GetExtensionArgument(CreationType.OptionSets, CrmSrvUtilService.NamingService).Value);
-            Settings.ExtensionConfig.SerializedMetadataRelativeFilePath = Path.Combine(Paths.LogsPath, "EBGV2.Metadata.xml");
+            if (Settings.ExtensionConfig.ReadSerializedMetadata || Settings.ExtensionConfig.SerializeMetadata)
+            {
+                Settings.ExtensionConfig.SerializedMetadataRelativeFilePath = Path.Combine(Paths.LogsPath, "EBGV2.Metadata.xml");
+            }
+            else
+            {
+                Settings.ExtensionConfig.SerializedMetadataRelativeFilePath = null;
+            }
         }
 
         private void LogConfigSettings()

--- a/DLaB.EarlyBoundGeneratorV2/EarlyBoundGeneratorV2.nuspec
+++ b/DLaB.EarlyBoundGeneratorV2/EarlyBoundGeneratorV2.nuspec
@@ -11,7 +11,9 @@
     <projectUrl>https://github.com/daryllabar/DLaB.Xrm.XrmToolBoxTools</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Generates Early Bound Entities/Option Sets/Messages.  Uses the DataverseModelBuilder from the SDK, and shows command line used to create the classes.</description>
-		<releaseNotes>V2.2026.6.7
+		<releaseNotes>Skip writing serializedMetadataRelativeFilePath when metadata serialization is unused #609
+
+V2.2026.6.7
 Obsolete attributed should be added to Field Name too, not only to Property #571
 			
 V2.2026.5.12


### PR DESCRIPTION
The `serializedMetadataRelativeFilePath` property was always being set and written to the EBG JSON settings file, even when neither `readSerializedMetadata` nor `serializeMetadata` was enabled. This clutters the settings with a path that has no effect at runtime.

This change conditionally sets and writes the property only when one of those two flags is true. When both are false, the value is cleared to null and omitted from the JSON output.